### PR TITLE
Created separate file-writer class + several bugfixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,13 @@
+#IDE
+.vscode
+
 # Old Stuff
 old/*
 
 # Data stuff
 src/data/*
+output-data/*
+*.csv
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,8 @@ services:
       [
         "python",
         "-u",
-        "broadcast_generated_power_line_data.py"
+        "broadcast_generated_power_line_data.py",
+        "0.1"
       ]
   client:
     # tty: true # docker run -t
@@ -23,3 +24,5 @@ services:
       - ZMQ_SUBS_IPV4=server
       - ZMQ_SUBS_PORT=5555
     command: [ "python", "-u", "src/main.py" ]
+    volumes:
+      - "./output-data:/maxwell-data-processor/output-data"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+#Numpy
+numpy
 # Queues
 zmq
 # Pydantic

--- a/servers/utils/generate_senoidal_data.py
+++ b/servers/utils/generate_senoidal_data.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime
 from time import sleep
 from typing import Iterator
 
@@ -29,8 +29,7 @@ def generate_senoidal_data(time_sleep: float) -> Iterator[ZeroMQMsg]:
     i_b = np.sin(omega * t - 2 * np.pi / 3)
     i_c = np.sin(omega * t + 2 * np.pi / 3)
 
-    start_date = datetime(2020, 1, 1)
-    timedelta_dt = timedelta(seconds=dt)
+    start_date = 1577836800.0
     dt_counter = start_date
     count = 0
     while True:
@@ -52,5 +51,5 @@ def generate_senoidal_data(time_sleep: float) -> Iterator[ZeroMQMsg]:
         print(f"[{datetime.now().strftime(FORMAT)}]Sending: {dt_counter}")
         yield zmq_message
         sleep(time_sleep)
-        dt_counter += timedelta_dt
+        dt_counter += dt
         count = count % n

--- a/servers/utils/generate_senoidal_data.py
+++ b/servers/utils/generate_senoidal_data.py
@@ -23,11 +23,11 @@ def generate_senoidal_data(time_sleep: float) -> Iterator[ZeroMQMsg]:
     v_a = (
         np.sin(omega * t) + 0.5 * np.sin(3.0 * omega * t) + 0.2 * np.sin(5 * omega * t)
     )
-    v_b = np.sin(omega * t - 2 * np.pi / 3)
-    v_c = np.sin(omega * t + 2 * np.pi / 3)
+    v_b = np.sin(omega * t - (2 * np.pi / 3))
+    v_c = np.sin(omega * t + (2 * np.pi / 3))
     i_a = np.sin(omega * t)
-    i_b = np.sin(omega * t - 2 * np.pi / 3)
-    i_c = np.sin(omega * t + 2 * np.pi / 3)
+    i_b = np.sin(omega * t - (2 * np.pi / 3))
+    i_c = np.sin(omega * t + (2 * np.pi / 3))
 
     start_date = 1577836800.0
     dt_counter = start_date
@@ -52,4 +52,5 @@ def generate_senoidal_data(time_sleep: float) -> Iterator[ZeroMQMsg]:
         yield zmq_message
         sleep(time_sleep)
         dt_counter += dt
+        count += 1
         count = count % n

--- a/servers/utils/send_msg.py
+++ b/servers/utils/send_msg.py
@@ -9,7 +9,5 @@ def send_msg(socket: Socket, msg: ZeroMQMsg) -> None:
     try:
         client_msg = json.dumps(msg, default=str)
         socket.send_string(client_msg)
-        # server_msg = socket.recv()
-        # print("Received reply {}".format(server_msg))
     except Exception as e:
         raise Exception("Socket Timeout: {}".format(str(e)))

--- a/src/configs/configs.py
+++ b/src/configs/configs.py
@@ -7,6 +7,7 @@ from pydantic import BaseSettings
 
 class Configs(BaseSettings):
     LOG_PATH: Optional[str]
+    ROOT_DIR: str = "/maxwell-data-processor/output-data"
 
     class Config:
         env_file = join(dirname(realpath(__file__)), ".env")

--- a/src/main_old.py
+++ b/src/main_old.py
@@ -2,7 +2,7 @@ import logging
 
 from configs import LOG_CONFIGS
 from processes import zmq_process
-from services import FileBufferService
+from services import zmq_client_buffer_service
 
 logging.basicConfig(**LOG_CONFIGS)
 logger = logging.getLogger(__name__)
@@ -10,9 +10,7 @@ logger = logging.getLogger(__name__)
 
 def main():
     try:
-        file_buffer_service = FileBufferService()
-        zmq_process(file_buffer_service.writer)
-        
+        zmq_process(zmq_client_buffer_service)
     except Exception as e:
         logger.warning(str(e))
 

--- a/src/processes/zmq_process.py
+++ b/src/processes/zmq_process.py
@@ -1,7 +1,8 @@
+from typing import Callable, Optional
+
 from infra.zmq import ZMQClient
-from services import zmq_client_buffer_service
 
 
-def zmq_process():
-    zmq_server = ZMQClient(callback=zmq_client_buffer_service)
+def zmq_process(callback: Optional[Callable] = None):
+    zmq_server = ZMQClient(callback=callback)
     zmq_server.run()

--- a/src/py_types/zmq_typing.py
+++ b/src/py_types/zmq_typing.py
@@ -1,9 +1,7 @@
 from typing import TypedDict
-from datetime import datetime
-
 
 class ZeroMQMsgBody(TypedDict):
-    dt: datetime
+    dt: float
     VA: float
     VB: float
     VC: float

--- a/src/services/__init__.py
+++ b/src/services/__init__.py
@@ -1,2 +1,3 @@
 # Buffer
 from .zmq_client_buffer_service import zmq_client_buffer_service
+from .file_buffer_service import FileBufferService

--- a/src/services/file_buffer_service.py
+++ b/src/services/file_buffer_service.py
@@ -1,0 +1,54 @@
+from io import BufferedWriter
+import os
+import uuid
+from struct import pack as struct_pack
+from datetime import datetime
+# import logging
+
+from py_types import ZeroMQMsg
+from configs import configs
+
+
+
+class FileBufferService:
+    # Object properties
+    file_path: str
+    file_buffer: BufferedWriter
+    # Private variables
+    __format: str = "%Y-%m-%d %H:%M:%S"
+    # __logger: logging.Logger = logging.getLogger(__file__)
+
+    def __init__(self):
+        dirname = configs.ROOT_DIR
+        file_name =  f"{uuid.uuid1()}-data-storage.dat"
+        self.file_path = os.path.join(dirname, file_name)
+        self.file_buffer = open(self.file_path, "ab")
+    
+    def __exit__(self):
+        self.file_buffer.flush()
+        self.file_buffer.close()
+    
+    def writer(self, msg: ZeroMQMsg):
+        dt = msg["msg_body"]["dt"]
+        va = msg["msg_body"]["VA"]
+        vb = msg["msg_body"]["VB"]
+        vc = msg["msg_body"]["VC"]
+        ia = msg["msg_body"]["IA"]
+        ib = msg["msg_body"]["IB"]
+        ic = msg["msg_body"]["IC"]
+        # self.__logger.info(
+        #     "[%(current_timestamp)s] Receiving: %(faraday_timestamp)s",
+        #     dict(
+        #         current_timestamp=datetime.now(),
+        #         faraday_timestamp=datetime.utcfromtimestamp(dt),
+        #     ),
+        # )
+        print(
+            f"[{datetime.now().strftime(self.__format)}]"
+            f" | Receiving: {datetime.utcfromtimestamp(dt).isoformat()}"
+        )
+        try:
+            self.file_buffer.write(struct_pack("7d", dt, va, vb, vc, ia, ib, ic))
+        except Exception as e:
+            raise Exception("Couldn't write on file, exiting service") from e
+

--- a/src/services/zmq_client_buffer_service.py
+++ b/src/services/zmq_client_buffer_service.py
@@ -1,6 +1,13 @@
+import os
+import uuid
+from struct import pack as struct_pack
 from datetime import datetime
 
 from py_types import Buffer, ZeroMQMsg
+
+dirname = "/maxwell-data-processor/output-data"
+file_name =  f"{uuid.uuid1()}-data-storage.dat"
+file_path = os.path.join(dirname, file_name)
 
 ZMQ_CLIENT_BUFFER = Buffer(
     dt=[],
@@ -18,7 +25,7 @@ def zmq_client_buffer_service(msg: ZeroMQMsg):
     dt = msg["msg_body"]["dt"]
     print(
         f"[{datetime.now().strftime(FORMAT)}]"
-        f"Length: {str(len(ZMQ_CLIENT_BUFFER.VA)).zfill(2)} | Receiving: {dt}"
+        f"Length: {str(len(ZMQ_CLIENT_BUFFER.VA)).zfill(2)} | Receiving: {datetime.utcfromtimestamp(dt).isoformat()}"
     )
     ZMQ_CLIENT_BUFFER.dt.append(msg["msg_body"]["dt"])
     ZMQ_CLIENT_BUFFER.VA.append(msg["msg_body"]["VA"])
@@ -31,11 +38,13 @@ def zmq_client_buffer_service(msg: ZeroMQMsg):
 
     if 32 <= len(ZMQ_CLIENT_BUFFER.VA):
         # Remove first value
-        ZMQ_CLIENT_BUFFER.dt.pop(0)
-        ZMQ_CLIENT_BUFFER.VA.pop(0)
-        ZMQ_CLIENT_BUFFER.VB.pop(0)
-        ZMQ_CLIENT_BUFFER.VC.pop(0)
-        ZMQ_CLIENT_BUFFER.IA.pop(0)
-        ZMQ_CLIENT_BUFFER.IB.pop(0)
-        ZMQ_CLIENT_BUFFER.IC.pop(0)
+        dt_o = ZMQ_CLIENT_BUFFER.dt.pop(0)
+        VA_o = ZMQ_CLIENT_BUFFER.VA.pop(0)
+        VB_o = ZMQ_CLIENT_BUFFER.VB.pop(0)
+        VC_o = ZMQ_CLIENT_BUFFER.VC.pop(0)
+        IA_o = ZMQ_CLIENT_BUFFER.IA.pop(0)
+        IB_o = ZMQ_CLIENT_BUFFER.IB.pop(0)
+        IC_o = ZMQ_CLIENT_BUFFER.IC.pop(0)
 
+        with open(file_path, "ab") as new_file:
+            new_file.write(struct_pack("7d", dt_o,VA_o ,VB_o ,VC_o ,IA_o, IB_o, IC_o))

--- a/src/services/zmq_client_buffer_service.py
+++ b/src/services/zmq_client_buffer_service.py
@@ -45,6 +45,3 @@ def zmq_client_buffer_service(msg: ZeroMQMsg):
         IA_o = ZMQ_CLIENT_BUFFER.IA.pop(0)
         IB_o = ZMQ_CLIENT_BUFFER.IB.pop(0)
         IC_o = ZMQ_CLIENT_BUFFER.IC.pop(0)
-
-        with open(file_path, "ab") as new_file:
-            new_file.write(struct_pack("7d", dt_o,VA_o ,VB_o ,VC_o ,IA_o, IB_o, IC_o))


### PR DESCRIPTION
- Logic for writing files was mixed with a 0MQ queue class reutilized from another repository from the project. Code was changed to better separate the functionalities in their appropriate classes, reflecting the visitor design pattern for the file writer class.
- Changed the file format to receive only the timestamps, voltage and current values. Removed the field that represented how many fields there were in any given line because it was redundant.
- Fixed a bug with the faux data generator. The loop counter that was used to update the values beamed through the 0MQ data was not being updated and thus the same value at index 0 was being sent repeatedly.